### PR TITLE
fix locale-dependent compiler output matching

### DIFF
--- a/icm_build_failure_parse_and_run.cmake
+++ b/icm_build_failure_parse_and_run.cmake
@@ -13,7 +13,7 @@ if(DEFINED CFG)
 endif()
 
 execute_process(
-    COMMAND ${CMAKE_COMMAND} --build . --target @ARG_TARGET@ ${cfgArg}
+    COMMAND ${CMAKE_COMMAND} -E env LC_ALL=C ${CMAKE_COMMAND} --build . --target @ARG_TARGET@ ${cfgArg}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     RESULT_VARIABLE res
     ERROR_VARIABLE out


### PR DESCRIPTION
Passes the LC_ALL=C for more deterministic results in compiler output matching.

In my case, GCC was using UTF-8 ‘quotes’ instead of ASCII 'quotes'.